### PR TITLE
add spider to crawl google finance news

### DIFF
--- a/r2d2/spiders/goo_fin.py
+++ b/r2d2/spiders/goo_fin.py
@@ -1,0 +1,27 @@
+import scrapy
+from googlefinance import getQuotes
+from googlefinance import getNews
+from scrapy.contrib.loader import ItemLoader
+from r2d2.items import NewsItem
+from scrapy.http.request import Request
+
+
+class GooFinSpider(scrapy.Spider):
+    name = "goo_fin"
+    symbols = ['GOOG']
+
+    def start_requests(self):
+        for symbol in self.symbols:
+            #stock = getQuotes(symbol)
+            news = getNews(symbol)
+            for article in news:
+                yield Request(article['u'],self.parse)            
+
+    def parse(self,response):
+        print "parse: ", response.url
+        item = NewsItem(url=response.url, title=response.xpath('//title/text()').extract(), 
+            content=response.xpath('//body//p//text()').extract())
+        yield item
+
+
+ 


### PR DESCRIPTION
scrapy runspider goo_fin.py
- get finance news related to stock GOOG
- extract the body text

Dependent module:
https://github.com/canojim/googlefinance/tree/finance-news
$ cd googlefinance
$ python setup.py install
